### PR TITLE
Update to SimpleSerial V2.1

### DIFF
--- a/main.c
+++ b/main.c
@@ -8,7 +8,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define SS_VER 2
+#define SS_VER SS_VER_2_1
 
 #include "simpleserial/simpleserial.h"
 

--- a/makefile
+++ b/makefile
@@ -36,7 +36,7 @@ TARGET = simpleserial-target
 # Header files (.h) are automatically pulled in.
 SRC += main.c
 
-SS_VER=SS_VER_2_0
+SS_VER=SS_VER_2_1
 PLATFORM=CWLITEARM
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
There is a newer version (V2.1) of SimpleSerial in the ChipWhisperer  repository. It replaces V2.0 which has been deprecated. This pull request should bring this template back up to date with the current release.